### PR TITLE
Bugfix: ugettext_lazy takes exactly 1 argument

### DIFF
--- a/snowpenguin/django/recaptcha3/fields.py
+++ b/snowpenguin/django/recaptcha3/fields.py
@@ -54,7 +54,7 @@ class ReCaptchaField(forms.CharField):
         if bool(json_response['success']):
             if self._score_threshold is not None and self._score_threshold > json_response['score']:
                 raise ValidationError(
-                    _('reCaptcha score is too low. score:%s', json_response['score'])
+                    _('reCaptcha score is too low. score:%s' % json_response['score'])
                 )
             return values[0]
         else:

--- a/snowpenguin/django/recaptcha3/tests.py
+++ b/snowpenguin/django/recaptcha3/tests.py
@@ -41,6 +41,7 @@ class TestRecaptchaForm(TestCase):
             recaptcha = ReCaptchaField(score_threshold=0.7)
         form = RecaptchaTestForm({"g-recaptcha-response": "dummy token"})
         self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['recaptcha'][0], 'reCaptcha score is too low. score:0.5')
 
     @mock.patch('requests.post')
     def test_validate_success_highter_score(self, requests_post):


### PR DESCRIPTION
Sorry. There was the bug in Pull Requests #2 from me.

`ugettext_lazy` must takes exactly 1 argument, not 2 argument.

This PR is fix of the bug. Please confirm and merge.

