### PR TITLE
RECAPTCHA_DISABLE improve

### DIFF
--- a/snowpenguin/django/recaptcha3/fields.py
+++ b/snowpenguin/django/recaptcha3/fields.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class ReCaptchaField(forms.CharField):
     def __init__(self, attrs=None, *args, **kwargs):
-        if os.environ.get('RECAPTCHA_DISABLE', None) is not None:
+        if os.environ.get('RECAPTCHA_DISABLE', None) is None:
             self._private_key = kwargs.pop('private_key', settings.RECAPTCHA_PRIVATE_KEY)
             self._score_threshold = kwargs.pop('score_threshold', settings.RECAPTCHA_SCORE_THRESHOLD)
 

--- a/snowpenguin/django/recaptcha3/fields.py
+++ b/snowpenguin/django/recaptcha3/fields.py
@@ -15,8 +15,9 @@ logger = logging.getLogger(__name__)
 
 class ReCaptchaField(forms.CharField):
     def __init__(self, attrs=None, *args, **kwargs):
-        self._private_key = kwargs.pop('private_key', settings.RECAPTCHA_PRIVATE_KEY)
-        self._score_threshold = kwargs.pop('score_threshold', settings.RECAPTCHA_SCORE_THRESHOLD)
+        if os.environ.get('RECAPTCHA_DISABLE', None) is not None:
+            self._private_key = kwargs.pop('private_key', settings.RECAPTCHA_PRIVATE_KEY)
+            self._score_threshold = kwargs.pop('score_threshold', settings.RECAPTCHA_SCORE_THRESHOLD)
 
         if 'widget' not in kwargs:
             kwargs['widget'] = ReCaptchaHiddenInput()

--- a/snowpenguin/django/recaptcha3/templatetags/recaptcha3.py
+++ b/snowpenguin/django/recaptcha3/templatetags/recaptcha3.py
@@ -1,5 +1,8 @@
+import os
+
 from django import template
 from django.conf import settings
+from django.template.loader import get_template
 
 register = template.Library()
 
@@ -9,7 +12,6 @@ def recaptcha_key():
     return settings.RECAPTCHA_PUBLIC_KEY
 
 
-@register.inclusion_tag('snowpenguin/recaptcha/recaptcha_init.html')
 def recaptcha_init(public_key=None):
 
     return {
@@ -19,7 +21,6 @@ def recaptcha_init(public_key=None):
     }
 
 
-@register.inclusion_tag('snowpenguin/recaptcha/recaptcha_ready.html')
 def recaptcha_ready(public_key=None, action_name=None, custom_callback=None):
     return {
         'public_key': public_key or settings.RECAPTCHA_PUBLIC_KEY,
@@ -28,10 +29,23 @@ def recaptcha_ready(public_key=None, action_name=None, custom_callback=None):
     }
 
 
-@register.inclusion_tag('snowpenguin/recaptcha/recaptcha_execute.html')
 def recaptcha_execute(public_key=None, action_name=None, custom_callback=None):
     return {
         'public_key': public_key or settings.RECAPTCHA_PUBLIC_KEY,
         'action_name': action_name or settings.RECAPTCHA_DEFAULT_ACTION,
         'custom_callback': custom_callback
     }
+
+
+def return_empty_context(*args, **kwargs):
+    return ''
+
+
+if not os.environ.get('RECAPTCHA_DISABLE', None):
+    register.inclusion_tag(get_template('snowpenguin/recaptcha/recaptcha_init.html'))(recaptcha_init)
+    register.inclusion_tag(get_template('snowpenguin/recaptcha/recaptcha_ready.html'))(recaptcha_ready)
+    register.inclusion_tag(get_template('snowpenguin/recaptcha/recaptcha_execute.html'))(recaptcha_execute)
+else:
+    register.simple_tag(return_empty_context, name='recaptcha_init')
+    register.simple_tag(return_empty_context, name='recaptcha_ready')
+    register.simple_tag(return_empty_context, name='recaptcha_execute')


### PR DESCRIPTION
When` RECAPTCHA_DISABLE` is set, then:
- `RECAPTCHA_PRIVATE_KEY` and `RECAPTCHA_PUBLIC_KEY` is not needed.
- JS code is not used in templates (not generate js errors and recaptcha is not checked)

Future update proposal:
`RECAPTCHA_DISABLE` should be set normal in settings, without using `os.environ`. Then developer can decide how to set it, eg:
- `RECAPTCHA_DISABLE = os.environ.get('RECAPTCHA_DISABLE', None)`
or
- `RECAPTCHA_DISABLE = env('RECAPTCHA_DISABLE', default=None)`
or
- settings.test.py: `RECAPTCHA_DISABLE = True`, settings.prod.py: `RECAPTCHA_DISABLE = False`
