### PR TITLE
Expose score, action, hostname in Form cleaned_data without mock response

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ os.environ['RECAPTCHA_DISABLE'] = 'True'
 ```
 You can use any word in place of "True", the clean function will check only if the variable exists.
 
-If you set `RECAPTCHA_DISABLE` to be valid json, it will be interpreted as a mock capatcha server response allowing you to mock score/hostname/action as required:
+If you set `RECAPTCHA_DISABLE` to be valid json, it will be interpreted as a mock captcha server response allowing you to mock score/hostname/action as required:
 ```python
 os.environ['RECAPTCHA_DISABLE'] = json.dumps({'score': 0.4, 'hostname': 'localhost', 'action': 'homepage'})
 ```

--- a/snowpenguin/django/recaptcha3/fields.py
+++ b/snowpenguin/django/recaptcha3/fields.py
@@ -28,7 +28,13 @@ class ReCaptchaField(forms.CharField):
 
         # Disable the check if we run a test unit
         if os.environ.get('RECAPTCHA_DISABLE', None) is not None:
-            return values[0]
+            return {
+                "success": True,
+                "score": 1.0,
+                "action": "",
+                "challenge_ts": "yyyy-MM-dd'T'HH:mm:ssZZ",
+                "hostname": "",
+            }
 
         super(ReCaptchaField, self).clean(values[0])
         response_token = values[0]
@@ -60,7 +66,7 @@ class ReCaptchaField(forms.CharField):
                     code='score',
                     params={'score': json_response['score']},
                 )
-            return values[0]
+            return json_response
         else:
             if 'error-codes' in json_response:
                 if 'missing-input-secret' in json_response['error-codes'] or \

--- a/snowpenguin/django/recaptcha3/tests.py
+++ b/snowpenguin/django/recaptcha3/tests.py
@@ -17,6 +17,7 @@ class TestRecaptchaForm(TestCase):
         os.environ['RECAPTCHA_DISABLE'] = 'True'
         form = RecaptchaTestForm({})
         self.assertTrue(form.is_valid())
+        self.assertEquals(form.recaptcha.score, 1.0)
         del os.environ['RECAPTCHA_DISABLE']
 
     @mock.patch('requests.post')
@@ -48,7 +49,9 @@ class TestRecaptchaForm(TestCase):
 
         recaptcha_response = {
             'success': True,
-            'score': 0.7
+            'score': 0.7,
+            'hostname': 'example.com',
+            'action': 'click'
         }
         requests_post.return_value.json = lambda: recaptcha_response
 
@@ -56,6 +59,9 @@ class TestRecaptchaForm(TestCase):
             recaptcha = ReCaptchaField(score_threshold=0.4)
         form = RecaptchaTestForm({"g-recaptcha-response": "dummy token"})
         self.assertTrue(form.is_valid())
+        self.assertEquals(form.recaptcha.score, 0.7)
+        self.assertEquals(form.recaptcha.hostname, 'example.com')
+        self.assertEquals(form.recaptcha.action, 'click')
 
     @mock.patch('requests.post')
     def test_settings_score_threshold(self, requests_post):


### PR DESCRIPTION
Similar to #17 with fewer changes - We no longer have a mocked result to return when `RECAPTCHA_DISABLE` is set, although the developer can inject a mock response if they wish.

---
Expose the score, action and hostname that come from the server during validation as the FormField's cleaned_data attribute. Emphasise that whilst we can make a bot/human decision by setting score_threshold or RECAPTCHA_SCORE_THRESHOLD , it is perfectly fine to use this module just to retrieve/record the scores for later processing.

Changes to unit test and README to cover these cases. The raw client-provided token has no real value ending up in the form's cleaned_data, and there were no tests broken by removing it. 