### PR TITLE
fix(recaptcha): extract token from first list item in clean()

### DIFF
--- a/snowpenguin/django/recaptcha3/fields.py
+++ b/snowpenguin/django/recaptcha3/fields.py
@@ -34,7 +34,8 @@ class ReCaptchaField(forms.CharField):
             except:
                 return {}
 
-        response_token = super(ReCaptchaField, self).clean(values)
+        super(ReCaptchaField, self).clean(values[0])
+        response_token = values[0]
 
         try:
             r = requests.post(

--- a/snowpenguin/django/recaptcha3/fields.py
+++ b/snowpenguin/django/recaptcha3/fields.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 class ReCaptchaField(forms.CharField):
     def __init__(self, attrs=None, *args, **kwargs):
-        if os.environ.get('RECAPTCHA_DISABLE', None) is None:
+        disable = os.environ.get('RECAPTCHA_DISABLE', '').lower() == 'true'
+        if not disable:
             self._private_key = kwargs.pop('private_key', settings.RECAPTCHA_PRIVATE_KEY)
             self._score_threshold = kwargs.pop('score_threshold', settings.RECAPTCHA_SCORE_THRESHOLD)
 
@@ -30,7 +31,7 @@ class ReCaptchaField(forms.CharField):
         # Disable the check (and allow empty field value) if we run in a unittest
         if os.environ.get('RECAPTCHA_DISABLE', '').lower() == 'true':
             try:
-                return json.loads(os.environ.get('RECAPTCHA_DISABLE', 'true'))
+                return {}
             except:
                 return {}
 

--- a/snowpenguin/django/recaptcha3/fields.py
+++ b/snowpenguin/django/recaptcha3/fields.py
@@ -28,9 +28,9 @@ class ReCaptchaField(forms.CharField):
 
     def clean(self, values):
         # Disable the check (and allow empty field value) if we run in a unittest
-        if os.environ.get('RECAPTCHA_DISABLE', None) is not None:
+        if os.environ.get('RECAPTCHA_DISABLE', '').lower() == 'true':
             try:
-                return json.loads(os.environ.get('RECAPTCHA_DISABLE', None))
+                return json.loads(os.environ.get('RECAPTCHA_DISABLE', 'true'))
             except:
                 return {}
 

--- a/snowpenguin/django/recaptcha3/templatetags/recaptcha3.py
+++ b/snowpenguin/django/recaptcha3/templatetags/recaptcha3.py
@@ -41,8 +41,8 @@ def recaptcha_execute(public_key=None, action_name=None, custom_callback=None):
 def return_empty_context(*args, **kwargs):
     return ''
 
-
-if not os.environ.get('RECAPTCHA_DISABLE', None):
+disable = os.environ.get('RECAPTCHA_DISABLE', '').lower() == 'true'
+if not disable:
     register.inclusion_tag(get_template('snowpenguin/recaptcha/recaptcha_init.html'))(recaptcha_init)
     register.inclusion_tag(get_template('snowpenguin/recaptcha/recaptcha_ready.html'))(recaptcha_ready)
     register.inclusion_tag(get_template('snowpenguin/recaptcha/recaptcha_execute.html'))(recaptcha_execute)


### PR DESCRIPTION
fix(forms): use first value for reCAPTCHA token

The widget can submit g-recaptcha-response as a one-item list.
Passing the list string to CharField.clean() caused Google
/siteverify to return "invalid-input-response". We now read
values[0] and handle str/list safely.